### PR TITLE
Make sure only one line of debug info

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,10 +60,11 @@ module.exports = function (config) {
       path = '/' + path;
     }
 
-    debug('Request: %s %s', req.method, path);
     var matchingRoute = router.match('/' + method + path);
 
     if (!matchingRoute) return next();
+    
+    debug('Request: %s %s', req.method, path);
 
     res.setHeader('Content-Type', 'application/json');
     var response = matchingRoute.fn();


### PR DESCRIPTION
Hi, this is a great module, thank you.

I use swagger-mock-api to load several swagger file, so there would be several swagger-mock-api instance, while I request one url, all instance will log the request even it is miss-matched. 

one request will log serveral times, looks bad

Request: GET /users
Request: GET /users
Request: GET /users
Request: GET /users
