### PR TITLE
Fix array max/min option

### DIFF
--- a/dist/MockData.js
+++ b/dist/MockData.js
@@ -92,7 +92,7 @@ function generateSchema(definition) {
 
 function generateArray(schema) {
   var items = schema.items;
-  var options = schema.options || { min: 0, max: 10 };
+  var options = schema['x-type-options'] || { min: 0, max: 10 };
   var iterations = chance.integer(options);
 
   var ret = [];

--- a/src/MockData.js
+++ b/src/MockData.js
@@ -69,7 +69,7 @@ function generateSchema(definition) {
 
 function generateArray(schema) {
   let items = schema.items;
-  let options = schema.options || {min: 0, max: 10};
+  var options = schema['x-type-options'] || { min: 0, max: 10 };
   let iterations = chance.integer(options);
 
 


### PR DESCRIPTION
Hi This module is just what I wanted!

I try to limit array length but something wrong.
e.g.

``` test.yaml
paths:
  /pets:
    get:
      description: ...
      #...
      responses:
        200:
          description: pet response
          schema:
            x-type-options: # limit to 1or2 pets
              min: 1  
              max: 2
            type: array
            items:
              $ref: '#/definitions/Pet'
```

Following is invalid in swagger.

```
schema:
  options: 
    min: 1 
    max:2
```

This seems to be caused by #28894bcb1d1284088b3dfed826c1cac305546649 .
Thanks.
