### PR TITLE
Use application/json examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ module.exports = function(grunt) {
           middleware: [
             mockApi({
                   swaggerFile: path.join(__dirname, 'path to swagger YAML or JSON file'),
-                  watch: true // enable reloading the routes and schemas when the swagger file changes
+                  watch: true, // enable reloading the routes and schemas when the swagger file changes
+                  mock: {
+                    useExamples: false, //use application/json example
+                    extendExamples: false //extend example data with random values
+                  }
               })
           ],
         },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hoek": "~2.14.0",
     "randexp": "^0.4.2",
     "routes": "~2.0.0",
+    "strip-json-comments": "^2.0.1",
     "swagger-parser": "^3.4.1"
   },
   "devDependencies": {

--- a/src/ConfigureRouter.js
+++ b/src/ConfigureRouter.js
@@ -20,27 +20,31 @@ function correctPath(path) {
 }
 
 // wrapped MockData to satisfy eslint's no funciton definitions inside of loops
-function mock(schema) {
-  return MockData(schema);
+function mock(schema, configMock) {
+  return MockData(schema, configMock);
 }
 
-function generateResponse(potentialResponses) {
-  for (let k in potentialResponses) {
+function generateResponse(potentialResponses, configMock) {
+  let keys = Object.keys(potentialResponses);
+
+  keys.sort(); //use 200 example
+
+  for (const k of keys) {
     if (k === 'default') continue;
 
     let responseSchema = potentialResponses[k];
     let responseCode = parseInt(k, 10);
     if (responseCode > 199 && responseCode < 300) {
-      return mock.bind(null, responseSchema);
+      return mock.bind(null, responseSchema, configMock);
     }
   }
 
   if (potentialResponses.default) {
-    return mock.bind(null, potentialResponses.default);
+    return mock.bind(null, potentialResponses.default, configMock);
   }
 }
 
-export default function ConfigureRouter(paths) {
+export default function ConfigureRouter(paths, configMock) {
   let router = new Routes();
 
   for (let pk in paths) {
@@ -58,7 +62,7 @@ export default function ConfigureRouter(paths) {
         console.log('ADDING ROUTE: ', mk.toUpperCase() + ' ' + pk);
       }
 
-      let respond = generateResponse(method.responses, pk);
+      let respond = generateResponse(method.responses, configMock);
       router.addRoute('/' + mk + route, respond);
     }
   }

--- a/src/MockData.js
+++ b/src/MockData.js
@@ -1,14 +1,27 @@
 'use strict';
 
-import Chance from 'chance';
-import hoek from 'hoek';
 import Parser from './Parsers/Parser'
 let parser = new Parser();
 
-export default function MockData(definition) {
+export default function MockData(definition, configMock) {
   let schema = definition.schema;
 
   if (!schema) return null;
 
-  return parser.parse(schema);
+  let mock = {};
+  if (configMock.useExamples) {
+    if (configMock.useExamples && definition.examples && definition.examples['application/json']) {
+      mock = definition.examples['application/json'];
+    }
+
+    if (configMock.extendExamples) {
+      mock = Object.assign(parser.parse(schema), mock);
+    }
+  }
+  else {
+    mock = parser.parse(schema);
+  }
+
+
+  return mock;
 };

--- a/src/MockData.js
+++ b/src/MockData.js
@@ -1,6 +1,9 @@
 'use strict';
 
+import stripJsonComments from 'strip-json-comments';
+
 import Parser from './Parsers/Parser'
+
 let parser = new Parser();
 
 export default function MockData(definition, configMock) {
@@ -8,20 +11,30 @@ export default function MockData(definition, configMock) {
 
   if (!schema) return null;
 
-  let mock = {};
-  if (configMock.useExamples) {
-    if (configMock.useExamples && definition.examples && definition.examples['application/json']) {
-      mock = definition.examples['application/json'];
-    }
+  let mock = null;
 
-    if (configMock.extendExamples) {
-      mock = Object.assign(parser.parse(schema), mock);
+  if (configMock.useExamples) {
+    if (configMock.useExamples && definition.examples) {
+      let keys = Object.keys(definition.examples);
+      let key = keys.find(function(obj) {
+        return obj.includes('json');
+      });
+      if (key) {
+        mock = definition.examples[key];
+        if (typeof(mock) === 'string') {
+          mock = stripJsonComments(mock);
+          mock = JSON.parse(mock);
+        }
+      }
+      if (configMock.extendExamples) {
+        mock = Object.assign(parser.parse(schema), mock);
+      }
     }
   }
-  else {
+
+  if (!mock) {
     mock = parser.parse(schema);
   }
-
 
   return mock;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default function(config) {
     }
 
     basePath = api.basePath || '';
-    router = ConfigureRouter(api.paths);
+    router = ConfigureRouter(api.paths, config.mock || {});
   }
 
   return function(req, res, next) {


### PR DESCRIPTION
Enable return examples

``` yaml
paths:
  /users/{userId}:
    get:
      ...
      responses:
        200:
          description: "The user object"
          schema:
            $ref: "#/definitions/User"
          examples:
            application/json:  {
                                  "userId": "1",
                                  "firstName": "Peter",
                                  "lastName": "Pan",
                                  "email": "peter.pan@example.org",
                                  "birthDate": "27/11/1984",
                              }
        ...
```

Usage:

``` js
mockApi({
    swaggerFile: path.join(__dirname, 'path/to/swagger.yaml'),
    watch: true, // enable reloading the routes and schemas when the swagger file changes
    mock: {
        useExamples: true,
        extendExamples: false
    }
})
```
