### PR TITLE
remove wildcards from paths

### DIFF
--- a/src/ConfigureRouter.js
+++ b/src/ConfigureRouter.js
@@ -11,6 +11,7 @@ function correctPath(path) {
       let segment = s;
       if (segment.charAt(0) === '{' && segment.charAt(segment.length - 1) === '}') {
         segment = segment.slice(1, -1);
+        segment = segment.replace(/(\-|\?|\*)/g, ''); //remove wildcards
         return ':' + segment;
       }
 


### PR DESCRIPTION
If the path has a wildcard, the match with the regex wont work.

Example:

```
path: /users/{user-id}
convert: '/get/users/:user-id'
regex: /^\/get\/users\/(?:([^\/]+?))-id\/?$/i
```
